### PR TITLE
Fix issue when single_header is given

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -170,7 +170,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -178,7 +178,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name


### PR DESCRIPTION
Tested with 
field_to_match = {
          single_header = {
            name = "user-agent"
          }
        }

Also changed it for single_query_argument

## what
* Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
* Use bullet points to be concise and to the point.

## why
* Provide the justifications for the changes (e.g. business case). 
* Describe why these changes were made (e.g. why do these commits fix the problem?)
* Use bullet points to be concise and to the point.

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
* Use `closes #123`, if this PR closes a GitHub issue `#123`

