### PR TITLE
fix(regex-rule): bugfix for attribute lookup

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -488,7 +488,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -496,7 +496,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name


### PR DESCRIPTION
## what

- Added the right attribute lookup logic for the `single_header` and the `single_query_argument` blocks of code regarding the `regex_pattern_set_reference_statement_rules` dynamic block.

  This was done to rectify a misconfiguration and also follows the existing configuration design.

## why

- Attribute lookup failed for single_header. The following screenshot was the error I was receiving

```hcl
│  420:                     name = single_header.value.name
│     ├────────────────
│     │ single_header.value is 1
│
│ Can't access attributes on a primitive-typed value (number).
```


## references

Similar issue to https://github.com/cloudposse/terraform-aws-waf/pull/10
closes #10 


