### PR TITLE
Fix single-header and single-query-argument attributes lookup

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -170,7 +170,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -178,7 +178,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name
@@ -645,7 +645,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -653,7 +653,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name
@@ -753,7 +753,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -761,7 +761,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name
@@ -860,7 +860,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -868,7 +868,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name


### PR DESCRIPTION
## what
* Added the right attribute lookup logic for the single_header and the single_query_argument blocks of code regarding the byte_match_statement/size_constraint_statement/sqli_match_statement/xss_match_statement dynamic blocks.

## why
* Attribute lookup failed for single_header. The following screenshot was the error I was receiving
```
│   on .terraform\modules\xxxxxxx\rules.tf line 176, in resource "xxxxxxxx" "default":
│  176:                     name = single_header.value.name
│     ├────────────────
│     │ single_header.value is 1
│
│ Can't access attributes on a primitive-typed value (number).

```
## references
* Similar issues #10 and #13

