### PR TITLE
Stop replacing single_header & single_query_argument with an int

### DIFF
--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -17,7 +17,6 @@ version-resolver:
     - 'bugfix'
     - 'bug'
     - 'hotfix'
-    - 'no-release'
   default: 'minor'
 
 categories:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,9 +4,9 @@
     ":preserveSemverRanges"
   ],
   "labels": ["auto-update"],
+  "dependencyDashboardAutoclose": true,
   "enabledManagers": ["terraform"],
   "terraform": {
     "ignorePaths": ["**/context.tf", "examples/**"]
   }
 }
-

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyrights
 
-Copyright © 2021-2022 [Cloud Posse, LLC](https://cloudposse.com)
+Copyright © 2021-2023 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 
@@ -420,7 +420,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-waf&utm_content=docs
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=cloudposse/terraform-aws-waf&utm_content=website
@@ -451,3 +451,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/cloudposse/terraform-aws-waf
   [share_email]: mailto:?subject=terraform-aws-waf&body=https://github.com/cloudposse/terraform-aws-waf
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/cloudposse/terraform-aws-waf?pixel&cs=github&cm=readme&an=terraform-aws-waf
+<!-- markdownlint-restore -->

--- a/rules.tf
+++ b/rules.tf
@@ -170,7 +170,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -178,7 +178,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name
@@ -645,7 +645,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -653,7 +653,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name
@@ -753,7 +753,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -761,7 +761,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name
@@ -860,7 +860,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_header" {
-                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
 
                   content {
                     name = single_header.value.name
@@ -868,7 +868,7 @@ resource "aws_wafv2_web_acl" "default" {
                 }
 
                 dynamic "single_query_argument" {
-                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [1] : []
+                  for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
 
                   content {
                     name = single_query_argument.value.name


### PR DESCRIPTION
## what
* Some parts of statements get replaced by the number `1`, resulting in an error when trying to access its `name` attribute

## why
* `single_header` and `single_query_argument` are unusable without a `name` attribute

## references
* closes #2

