### PR TITLE
Changes made to fix bug in the module example.

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "waf" {
   source = "../.."
-
+  name = var.waf_name
   geo_match_statement_rules = [
     {
       name     = "rule-10"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,3 +1,8 @@
 variable "region" {
   type = string
 }
+
+variable "waf_name" {
+  type        = string
+  description = "This variable contains the WAF WEB ACL Name"
+}


### PR DESCRIPTION
This fix is made for issue #20 .
The example for the module was not working so I went through the terraform code to see the issue. 
In context file, the name is being passed as null. The null value is not accepted for the :
metric name as well as the WAF name as both are mandatory.
Kindly review the code.