### PR TITLE
Changes made to fix bug in the module example.

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "waf" {
   source = "../.."
-
+  name = var.waf_name
   geo_match_statement_rules = [
     {
       name     = "rule-10"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,3 +1,8 @@
 variable "region" {
   type = string
 }
+
+variable "waf_name" {
+  type        = string
+  description = "This variable contains the WAF WEB ACL Name"
+}


### PR DESCRIPTION
## what
Hello everyone. First of all, this is a great module ! 
Now the real reason : 
* Saw below issue when I tried to run terraform plan for module example :

│ Error: expected length of name to be in the range (1 - 128), got
│
│ with module.waf.aws_wafv2_web_acl.default[0],
│ on ....\rules.tf line 88, in resource "aws_wafv2_web_acl" "default":
│ 88: name = module.this.id
│
╵
╷
│ Error: invalid value for name (must contain only alphanumeric hyphen and underscore characters)
│
│ with module.waf.aws_wafv2_web_acl.default[0],
│ on ....\rules.tf line 88, in resource "aws_wafv2_web_acl" "default":
│ 88: name = module.this.id
│
╵
╷
│ Error: expected length of visibility_config.0.metric_name to be in the range (1 - 128), got
│
│ with module.waf.aws_wafv2_web_acl.default[0],
│ on ....\rules.tf line 107, in resource "aws_wafv2_web_acl" "default":
│ 107: metric_name = lookup(var.visibility_config, "metric_name", module.this.id)
│
╵
╷
│ Error: invalid value for visibility_config.0.metric_name (must contain only alphanumeric hyphen and underscore characters)
│
│ with module.waf.aws_wafv2_web_acl.default[0],
│ on ....\rules.tf line 107, in resource "aws_wafv2_web_acl" "default":
│ 107: metric_name = lookup(var.visibility_config, "metric_name", module.this.id)

## why
* The terraform example for the module is not working at all if we don't add the variable value. 
* If people are not able to test this module, it might now get noticed as much.
* I am fairly new to TF world and git world so hope to make a contribution.

## references
* #20 is linked with this issue. If this PR is approved, we might be able to close this issue.
