### PR TITLE
Support `action_to_use` `allow` with Managed Rule Group Statement Rules

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -179,6 +179,8 @@ variable "managed_rule_group_statement_rules" {
         The name of the managed rule group vendor.
       excluded_rule:
         The list of names of the rules to exclude.
+      allowed_rule:
+        The list of names of the rules to allow.
 
     visibility_config:
       Defines and enables Amazon CloudWatch metrics and web request sample collection.


### PR DESCRIPTION
## what
- Added allowed rules as an option for managed_rule_group_statement_rules

## why
- Currently only `excluded` rules are available, yet we want to be able to set the `action_to_use` as `allow` explicitly as such:

```
                 rule_action_override {
                      name = "SizeRestrictions_BODY"

                      action_to_use {
                          allow {
                            }
                        }
                    }
````

## references
- n/a

