### PR TITLE
Adding CAPTCHA action support to all actions

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.2.4"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 4.28.0"
     }
   }
 }

--- a/rules.tf
+++ b/rules.tf
@@ -100,11 +100,6 @@ resource "aws_wafv2_web_acl" "default" {
       for_each = var.default_action == "block" ? [1] : []
       content {}
     }
-
-    dynamic "captcha" {
-      for_each = var.default_action == "captcha" ? [1] : []
-      content {}
-    }
   }
 
   visibility_config {

--- a/rules.tf
+++ b/rules.tf
@@ -100,6 +100,11 @@ resource "aws_wafv2_web_acl" "default" {
       for_each = var.default_action == "block" ? [1] : []
       content {}
     }
+
+    dynamic "captcha" {
+      for_each = var.default_action == "captcha" ? [1] : []
+      content {}
+    }
   }
 
   visibility_config {

--- a/rules.tf
+++ b/rules.tf
@@ -242,10 +242,10 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = rule.value.action == "block" ? [1] : []
           content {}
         }
-        dynamic "count" {
-          for_each = rule.value.action == "count" ? [1] : []
-          content {}
-        }
+        # dynamic "count" {
+        #   for_each = rule.value.action == "count" ? [1] : []
+        #   content {}
+        # }
         dynamic "captcha" {
           for_each = rule.value.action == "captcha" ? [1] : []
           content {}

--- a/rules.tf
+++ b/rules.tf
@@ -619,6 +619,10 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = rule.value.action == "count" ? [1] : []
           content {}
         }
+        dynamic "captcha" {
+          for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
       }
       statement {
         dynamic "size_constraint_statement" {
@@ -728,6 +732,10 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = rule.value.action == "count" ? [1] : []
           content {}
         }
+        dynamic "captcha" {
+          for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
       }
 
       statement {
@@ -834,6 +842,10 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "count" {
           for_each = rule.value.action == "count" ? [1] : []
+          content {}
+        }
+        dynamic "captcha" {
+          for_each = rule.value.action == "captcha" ? [1] : []
           content {}
         }
       }

--- a/rules.tf
+++ b/rules.tf
@@ -239,7 +239,7 @@ resource "aws_wafv2_web_acl" "default" {
           content {}
         }
         dynamic "block" {
-          for_each = rule.value.action == "block1" ? [1] : []
+          for_each = rule.value.action == "block" ? [1] : []
           content {}
         }
         dynamic "count" {

--- a/rules.tf
+++ b/rules.tf
@@ -298,6 +298,10 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = rule.value.action == "count" ? [1] : []
           content {}
         }
+        dynamic "captcha" {
+          for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
       }
 
       statement {
@@ -398,6 +402,10 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "count" {
           for_each = rule.value.action == "count" ? [1] : []
+          content {}
+        }
+        dynamic "captcha" {
+          for_each = rule.value.action == "captcha" ? [1] : []
           content {}
         }
       }

--- a/rules.tf
+++ b/rules.tf
@@ -239,7 +239,7 @@ resource "aws_wafv2_web_acl" "default" {
           content {}
         }
         dynamic "block" {
-          for_each = rule.value.action == "block" ? [1] : []
+          for_each = rule.value.action == "block1" ? [1] : []
           content {}
         }
         dynamic "count" {

--- a/rules.tf
+++ b/rules.tf
@@ -246,6 +246,10 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = rule.value.action == "count" ? [1] : []
           content {}
         }
+        dynamic "captcha" {
+          for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
       }
 
       statement {

--- a/rules.tf
+++ b/rules.tf
@@ -237,10 +237,10 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = rule.value.action == "block" ? [1] : []
           content {}
         }
-        # dynamic "count" {
-        #   for_each = rule.value.action == "count" ? [1] : []
-        #   content {}
-        # }
+        dynamic "count" {
+          for_each = rule.value.action == "count" ? [1] : []
+          content {}
+        }
         dynamic "captcha" {
           for_each = rule.value.action == "captcha" ? [1] : []
           content {}

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@ variable "default_action" {
   default     = "block"
   description = "Specifies that AWS WAF should allow requests by default. Possible values: `allow`, `block`."
   validation {
-    condition     = contains(["allow", "block", "captcha"], var.default_action)
-    error_message = "Allowed values: `allow`, `block`, `captcha`."
+    condition     = contains(["allow", "block"], var.default_action)
+    error_message = "Allowed values: `allow`, `block`."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -3,8 +3,8 @@ variable "default_action" {
   default     = "block"
   description = "Specifies that AWS WAF should allow requests by default. Possible values: `allow`, `block`."
   validation {
-    condition     = contains(["allow", "block"], var.default_action)
-    error_message = "Allowed values: `allow`, `block`."
+    condition     = contains(["allow", "block", "captcha"], var.default_action)
+    error_message = "Allowed values: `allow`, `block`, `captcha`."
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.2.4"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.28.0"
+      version = ">= 2.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.2.4"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 4.28.0"
     }
   }
 }


### PR DESCRIPTION
## what
* Adding CAPTCHA action support
* Bumping terraform and aws provider versions (as they are 2 years old)

## why
* In our mostly geo location rule we need captcha for people to be able to access the website
* We had to use CAPTCHA in WAF rule but it was not supported

## references
* Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow)
* It was introduced in 4.21.0 AWS provider: https://github.com/hashicorp/terraform-provider-aws/issues/21754 
* Closes #28 issue

