### PR TITLE
Add ip_set support 

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -67,6 +67,9 @@ references:
   - name: aws_wafv2_web_acl_logging_configuration
     description: Creates a WAFv2 Web ACL Logging Configuration
     url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration.html
+  - name: aws_wafv2_ip_set
+    description: Creates a WAFv2 Web ACL resource
+    url: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_ip_set
 
 description: |-
   Terraform module to create and manage AWS WAFv2 rules. 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -254,5 +254,20 @@ module "waf" {
     }
   ]
 
+  ip_set_reference_statement_rules = [
+    {
+      name     = "rule-100"
+      priority = 100
+      action   = "block"
+
+      statement = {
+        ip_set = {
+          ip_address_version = "IPV4"
+          addresses          = ["17.0.0.0/8"]
+        }
+      }
+    }
+  ]
+
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -266,6 +266,12 @@ module "waf" {
           addresses          = ["17.0.0.0/8"]
         }
       }
+
+      visibility_config = {
+        cloudwatch_metrics_enabled = false
+        sampled_requests_enabled   = false
+        metric_name                = "rule-100-metric"
+      }
     }
   ]
 

--- a/ipset.tf
+++ b/ipset.tf
@@ -25,7 +25,7 @@ resource "aws_wafv2_ip_set" "default" {
   for_each = local.ip_sets
 
   name               = module.ip_set_label[each.key].id
-  description        = each.value.description
+  description        = lookup(each.value, "description", null)
   scope              = var.scope
   ip_address_version = each.value.ip_address_version
   addresses          = each.value.addresses

--- a/ipset.tf
+++ b/ipset.tf
@@ -5,9 +5,9 @@ locals {
     => rule.statement.ipset if try(rule.statement.ipset, null) != null && try(rule.statement.arn, null) == null
   } : {}
 
-  ip_reference_statement_rule_to_ip_set_arn = local.enabled && local.ip_set_reference_statement_rules != null ? {
+  ip_rule_to_ip_set = local.enabled && local.ip_set_reference_statement_rules != null ? {
     for name, rule in local.ip_set_reference_statement_rules :
-    name => aws_wafv2_ip_set.default[lookup(rule, "name", null) != null ? format("%s-ip-set", rule.name) : format("ip-set-%d", rule.priority)]
+    name => lookup(rule, "name", null) != null ? format("%s-ip-set", rule.name) : format("ip-set-%d", rule.priority)
   } : {}
 }
 

--- a/ipset.tf
+++ b/ipset.tf
@@ -2,7 +2,7 @@ locals {
   ip_sets = local.enabled && var.ip_set_reference_statement_rules != null ? {
     for indx, rule in flatten(var.ip_set_reference_statement_rules) :
     lookup(rule, "name", null) != null ? format("%s-ip-set", rule.name) : format("ip-set-%d", rule.priority)
-    => rule.statement.ipset if try(rule.statement.ipset, null) != null && try(rule.statement.arn, null) == null
+    => rule.statement.ipset
   } : {}
 
   ip_rule_to_ip_set = local.enabled && local.ip_set_reference_statement_rules != null ? {

--- a/ipset.tf
+++ b/ipset.tf
@@ -5,9 +5,9 @@ locals {
     => rule.statement.ipset if try(rule.statement.ipset, null) != null && try(rule.statement.arn, null) == null
   } : {}
 
-  ip_reference_statement_rule_to_ip_set = local.enabled && local.ip_set_reference_statement_rules != null ? {
+  ip_reference_statement_rule_to_ip_set_arn = local.enabled && local.ip_set_reference_statement_rules != null ? {
     for name, rule in local.ip_set_reference_statement_rules :
-    name => lookup(rule, "name", null) != null ? format("%s-ip-set", rule.name) : format("ip-set-%d", rule.priority)
+    name => aws_wafv2_ip_set.default[lookup(rule, "name", null) != null ? format("%s-ip-set", rule.name) : format("ip-set-%d", rule.priority)]
   } : {}
 }
 

--- a/ipset.tf
+++ b/ipset.tf
@@ -2,7 +2,7 @@ locals {
   ip_sets = local.enabled && var.ip_set_reference_statement_rules != null ? {
     for indx, rule in flatten(var.ip_set_reference_statement_rules) :
     lookup(rule, "name", null) != null ? format("%s-ip-set", rule.name) : format("ip-set-%d", rule.priority)
-    => rule.statement.ipset
+    => rule.statement.ip_set if try(rule.statement.ip_set, null) != null && try(rule.statement.arn, null) == null
   } : {}
 
   ip_rule_to_ip_set = local.enabled && local.ip_set_reference_statement_rules != null ? {

--- a/ipset.tf
+++ b/ipset.tf
@@ -1,0 +1,34 @@
+locals {
+  ip_sets = local.enabled && var.ip_set_reference_statement_rules != null ? {
+    for indx, rule in flatten(var.ip_set_reference_statement_rules) :
+    lookup(rule, "name", null) != null ? format("%s-ip-set", rule.name) : format("ip-set-%d", rule.priority)
+    => rule.statement.ipset if try(rule.statement.ipset, null) != null && try(rule.statement.arn, null) == null
+  } : {}
+
+  ip_reference_statement_rule_to_ip_set = local.enabled && local.ip_set_reference_statement_rules != null ? {
+    for name, rule in local.ip_set_reference_statement_rules :
+    name => lookup(rule, "name", null) != null ? format("%s-ip-set", rule.name) : format("ip-set-%d", rule.priority)
+  } : {}
+}
+
+module "ip_set_label" {
+  for_each = local.ip_sets
+
+  source  = "cloudposse/label/null"
+  version = "0.25.0"
+
+  attributes = [each.key]
+  context    = module.this.context
+}
+
+resource "aws_wafv2_ip_set" "default" {
+  for_each = local.ip_sets
+
+  name               = module.ip_set_label[each.key].id
+  description        = each.value.description
+  scope              = var.scope
+  ip_address_version = each.value.ip_address_version
+  addresses          = each.value.addresses
+
+  tags = module.this.tags
+}

--- a/rules.tf
+++ b/rules.tf
@@ -420,7 +420,7 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
 
           content {
-            arn = ip_set_reference_statement.value.arn
+            arn = lookup(ip_set_reference_statement.value, "arn", null) != null ? ip_set_reference_statement.value.arn : aws_wafv2_ip_set.default[local.ip_reference_statement_rule_to_ip_set[rule.key]].arn
 
             dynamic "ip_set_forwarded_ip_config" {
               for_each = lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", null) != null ? [ip_set_reference_statement.value.ip_set_forwarded_ip_config] : []

--- a/rules.tf
+++ b/rules.tf
@@ -420,7 +420,7 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
 
           content {
-            arn = try(local.ip_reference_statement_rule_to_ip_set_arn[rule.key], null) != null ? local.ip_reference_statement_rule_to_ip_set_arn[rule.key] : ip_set_reference_statement.value.arn
+            arn = try(aws_wafv2_ip_set.default[local.ip_rule_to_ip_set[rule.key]], null) != null ? aws_wafv2_ip_set.default[local.ip_rule_to_ip_set[rule.key]] : ip_set_reference_statement.value.arn
 
             dynamic "ip_set_forwarded_ip_config" {
               for_each = lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", null) != null ? [ip_set_reference_statement.value.ip_set_forwarded_ip_config] : []

--- a/rules.tf
+++ b/rules.tf
@@ -416,14 +416,17 @@ resource "aws_wafv2_web_acl" "default" {
       }
 
       statement {
-        dynamic "ip_set_reference_statement" {
-          for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
+        dynamic "ip_set" {
+          for_each = {
+            for name, ip_set in aws_wafv2_ip_set.default :
+            name => ip_set if name == local.ip_rule_to_ip_set[rule.key]
+          }
 
           content {
-            arn = aws_wafv2_ip_set.default[local.ip_rule_to_ip_set[rule.key]]
+            arn = ip_set.value.arn
 
             dynamic "ip_set_forwarded_ip_config" {
-              for_each = lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", null) != null ? [ip_set_reference_statement.value.ip_set_forwarded_ip_config] : []
+              for_each = try(rule.value.statement.ip_set_forwarded_ip_config, null) != null ? [rule.value.statement.ip_set_forwarded_ip_config] : []
 
               content {
                 fallback_behavior = ip_set_forwarded_ip_config.value.fallback_behavior

--- a/rules.tf
+++ b/rules.tf
@@ -416,7 +416,8 @@ resource "aws_wafv2_web_acl" "default" {
       }
 
       statement {
-        dynamic "ip_set" {
+        dynamic "ip_set_reference_statement" {
+          iterator = "ip_set"
           for_each = {
             for name, ip_set in aws_wafv2_ip_set.default :
             name => ip_set if name == local.ip_rule_to_ip_set[rule.key]

--- a/rules.tf
+++ b/rules.tf
@@ -1355,4 +1355,8 @@ resource "aws_wafv2_web_acl" "default" {
       }
     }
   }
+
+  depends_on = [
+    aws_wafv2_ip_set.default
+  ]
 }

--- a/rules.tf
+++ b/rules.tf
@@ -420,7 +420,7 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
 
           content {
-            arn = lookup(ip_set_reference_statement.value, "arn", null) != null ? ip_set_reference_statement.value.arn : aws_wafv2_ip_set.default[local.ip_reference_statement_rule_to_ip_set[rule.key]].arn
+            arn = lookup(ip_set_reference_statement.value, "arn", null) != null ? ip_set_reference_statement.value.arn : aws_wafv2_ip_set.default[lookup(local.ip_reference_statement_rule_to_ip_set, rule.key, "")].arn
 
             dynamic "ip_set_forwarded_ip_config" {
               for_each = lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", null) != null ? [ip_set_reference_statement.value.ip_set_forwarded_ip_config] : []

--- a/rules.tf
+++ b/rules.tf
@@ -420,7 +420,7 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
 
           content {
-            arn = lookup(ip_set_reference_statement.value, "arn", null) != null ? ip_set_reference_statement.value.arn : aws_wafv2_ip_set.default[lookup(local.ip_reference_statement_rule_to_ip_set, rule.key, "")].arn
+            arn = try(local.ip_reference_statement_rule_to_ip_set_arn[rule.key], null) != null ? local.ip_reference_statement_rule_to_ip_set_arn[rule.key] : ip_set_reference_statement.value.arn
 
             dynamic "ip_set_forwarded_ip_config" {
               for_each = lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", null) != null ? [ip_set_reference_statement.value.ip_set_forwarded_ip_config] : []

--- a/rules.tf
+++ b/rules.tf
@@ -420,7 +420,7 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
 
           content {
-            arn = try(aws_wafv2_ip_set.default[local.ip_rule_to_ip_set[rule.key]], null) != null ? aws_wafv2_ip_set.default[local.ip_rule_to_ip_set[rule.key]] : ip_set_reference_statement.value.arn
+            arn = aws_wafv2_ip_set.default[local.ip_rule_to_ip_set[rule.key]]
 
             dynamic "ip_set_forwarded_ip_config" {
               for_each = lookup(ip_set_reference_statement.value, "ip_set_forwarded_ip_config", null) != null ? [ip_set_reference_statement.value.ip_set_forwarded_ip_config] : []
@@ -1355,8 +1355,4 @@ resource "aws_wafv2_web_acl" "default" {
       }
     }
   }
-
-  depends_on = [
-    aws_wafv2_ip_set.default
-  ]
 }

--- a/rules.tf
+++ b/rules.tf
@@ -417,14 +417,13 @@ resource "aws_wafv2_web_acl" "default" {
 
       statement {
         dynamic "ip_set_reference_statement" {
-          iterator = "ip_set"
           for_each = {
             for name, ip_set in aws_wafv2_ip_set.default :
             name => ip_set if name == local.ip_rule_to_ip_set[rule.key]
           }
 
           content {
-            arn = ip_set.value.arn
+            arn = ip_set_reference_statement.value.arn
 
             dynamic "ip_set_forwarded_ip_config" {
               for_each = try(rule.value.statement.ip_set_forwarded_ip_config, null) != null ? [rule.value.statement.ip_set_forwarded_ip_config] : []

--- a/variables.tf
+++ b/variables.tf
@@ -329,6 +329,16 @@ variable "ip_set_reference_statement_rules" {
     statement:
       arn:
         The ARN of the IP Set that this statement references.
+      ip_set:
+        Defines a new IP Set
+
+        description:
+          A friendly description of the IP Set
+        addresses:
+          Contains an array of strings that specifies zero or more IP addresses or blocks of IP addresses.
+          All addresses must be specified using Classless Inter-Domain Routing (CIDR) notation.
+        ip_address_version:
+          Specify `IPV4` or `IPV6`
       ip_set_forwarded_ip_config:
         fallback_behavior:
           The match status to assign to the web request if the request doesn't have a valid IP address in the specified position.


### PR DESCRIPTION
## what

- Add `ip_set` variable in `ip_set_reference_statement_rules` to create IP Set automatically

## why

- If the IP set is not shared, there is no need to have separate from the WAF module
- It allows a user of atmos to continue defining all their rules in yaml, otherwise they have to use tf code to forward the ARN to this module
