### PR TITLE
fix: content_type for custom_response_body definition

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -122,7 +122,7 @@ resource "aws_wafv2_web_acl" "default" {
     content {
       key          = custom_response_body.key
       content      = custom_response_body.value.content
-      content_type = custom_response_body.value.content
+      content_type = custom_response_body.value.content_type
     }
   }
 


### PR DESCRIPTION
## what

The definition of the custom responses is wrong. content_type should not be equal to content. It should be equal to the content_type input

## why

Throws an error if you put anything but valid content_types into the content field

