### PR TITLE
Add default_custom_response_body_key var

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -111,6 +111,7 @@ resource "aws_wafv2_web_acl" "default" {
         dynamic "custom_response" {
           for_each = var.default_block_response != null ? [true] : []
           content {
+            custom_response_body_key = var.default_custom_response_body_key
             response_code = var.default_block_response
           }
         }

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,16 @@ variable "default_action" {
   }
 }
 
+variable "default_custom_response_body_key" {
+  type        = string
+  default     = null
+  nullable    = true
+  description = <<-DOC
+    The key to use to assign the default custom response body.
+    It corresponds to a `key` attribute of the `custom_response_body` map(object({})).
+  DOC
+}
+
 variable "custom_response_body" {
   type = map(object({
     content      = string


### PR DESCRIPTION
## what

- add a new variable `default_custom_response_body_key` 
- used in new (missing) element `default_action.block.custom_response.custom_response_body_key`

## why

- the `default_action.block.custom_response` only allows for defining a custom response code
- when using this module we'd always get a diff with our desired config.

## references

- unsolicited, thought to contribute back this change we are running live. 
- happy to modify if non-conformant to cloudposse standard.
- thanks for all the modules over the years

