### PR TITLE
Add scope down statement support

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -745,17 +745,84 @@ resource "aws_wafv2_web_acl" "default" {
                 header_name       = forwarded_ip_config.value.header_name
               }
             }
-          }
-        }
 
-        dynamic "scope_down_statement" {
-          for_each = lookup(rate_based_statement.value, "scope_down_statement", null) != null ? [rate_based_statement.value.scope_down_statement] : []
-
-          content {
-            dynamic "and_statement" {
+            dynamic "scope_down_statement" {
+              for_each = lookup(rate_based_statement.value, "scope_down_statement", null) != null ? [rate_based_statement.value.scope_down_statement] : []
 
               content {
-                statement = rate_based_statement.value.scope_down_statement.and_statement.statement
+                dynamic "byte_match_statement" {
+                  for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
+
+                  content {
+                    positional_constraint = byte_match_statement.value.positional_constraint
+                    search_string         = byte_match_statement.value.search_string
+
+                    dynamic "field_to_match" {
+                      for_each = lookup(rule.value.statement, "field_to_match", null) != null ? [rule.value.statement.field_to_match] : []
+
+                      content {
+                        dynamic "all_query_arguments" {
+                          for_each = lookup(field_to_match.value, "all_query_arguments", null) != null ? [1] : []
+
+                          content {}
+                        }
+
+                        dynamic "body" {
+                          for_each = lookup(field_to_match.value, "body", null) != null ? [1] : []
+
+                          content {}
+                        }
+
+                        dynamic "method" {
+                          for_each = lookup(field_to_match.value, "method", null) != null ? [1] : []
+
+                          content {}
+                        }
+
+                        dynamic "query_string" {
+                          for_each = lookup(field_to_match.value, "query_string", null) != null ? [1] : []
+
+                          content {}
+                        }
+
+                        dynamic "single_header" {
+                          for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
+
+                          content {
+                            name = single_header.value.name
+                          }
+                        }
+
+                        dynamic "single_query_argument" {
+                          for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
+
+                          content {
+                            name = single_query_argument.value.name
+                          }
+                        }
+
+                        dynamic "uri_path" {
+                          for_each = lookup(field_to_match.value, "uri_path", null) != null ? [1] : []
+
+                          content {}
+                        }
+                      }
+                    }
+
+                    dynamic "text_transformation" {
+                      for_each = lookup(rule.value.statement, "text_transformation", null) != null ? [
+                        for rule in lookup(rule.value.statement, "text_transformation") : {
+                          priority = rule.priority
+                          type     = rule.type
+                      }] : []
+
+                      content {
+                        priority = text_transformation.value.priority
+                        type     = text_transformation.value.type
+                      }
+                    }
+                  }
+                }
               }
             }
           }

--- a/rules.tf
+++ b/rules.tf
@@ -747,6 +747,19 @@ resource "aws_wafv2_web_acl" "default" {
             }
           }
         }
+
+        dynamic "scope_down_statement" {
+          for_each = lookup(rate_based_statement.value, "scope_down_statement", null) != null ? [rate_based_statement.value.scope_down_statement] : []
+
+          content {
+            dynamic "and_statement" {
+
+              content {
+                statement = rate_based_statement.value.scope_down_statement.and_statement.statement
+              }
+            }
+          }
+        }
       }
 
       dynamic "visibility_config" {

--- a/variables.tf
+++ b/variables.tf
@@ -549,9 +549,19 @@ variable "rate_based_statement_rules" {
           Position in the header to search for the IP address.
           
       scope_down_statement:
-        Narrows the scope of the rate-based statement to matching web requests. This can be any nestable statement,
-        and you can nest statements at any level below this scope-down statement.
-        For more information, see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#statement-block
+        Narrows the scope of the rate-based statement to matching web requests.
+        For more information, see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html#scope_down_statement
+        byte_match_statement:
+          positional_constraint:
+          Area within the portion of a web request that you want AWS WAF to search for search_string. Valid values include the following: EXACTLY, STARTS_WITH, ENDS_WITH, CONTAINS, CONTAINS_WORD.
+        search_string
+          String value that you want AWS WAF to search for. AWS WAF searches only in the part of web requests that you designate for inspection in field_to_match.
+        field_to_match:
+          The part of a web request that you want AWS WAF to inspect.
+          See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#field-to-match
+        text_transformation:
+          Text transformations eliminate some of the unusual formatting that attackers use in web requests in an effort to bypass detection.
+          See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#text-transformation
 
     visibility_config:
       Defines and enables Amazon CloudWatch metrics and web request sample collection.

--- a/variables.tf
+++ b/variables.tf
@@ -545,6 +545,13 @@ variable "rate_based_statement_rules" {
           Possible values: `MATCH`, `NO_MATCH`
         header_name:
           The name of the HTTP header to use for the IP address.
+        position:
+          Position in the header to search for the IP address.
+          
+      scope_down_statement:
+        Narrows the scope of the rate-based statement to matching web requests. This can be any nestable statement,
+        and you can nest statements at any level below this scope-down statement.
+        For more information, see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl#statement-block
 
     visibility_config:
       Defines and enables Amazon CloudWatch metrics and web request sample collection.


### PR DESCRIPTION
## what

AWS highly recommends safeguarding against HTTP request floods; they advise implementing two rate limiting rules for web traffic. The initial rule employs AWS WAF's rate-based rules to automatically block IP addresses of malicious actors if the number of requests in a 5-minute sliding window surpasses a predefined threshold. The second rule focuses on a more detailed approach, allowing for targeted blocking. This is achieved by using `scope_down_statements` to refine the criteria for blocking, enhancing the precision of the defense mechanism.

## why

- Adds `scope_down_statements` with byte matching support

## references

- [AWS WAF – Rate-based rules](https://docs.aws.amazon.com/whitepapers/latest/aws-best-practices-ddos-resiliency/aws-waf-rate-based-rules.html)
- [Rate-based rule request rate limiting behavior](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based-request-limiting.html)
- [Terraform Resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl.html)