### PR TITLE
Fix Scope Down Statement Rule

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -751,14 +751,14 @@ resource "aws_wafv2_web_acl" "default" {
 
               content {
                 dynamic "byte_match_statement" {
-                  for_each = lookup(rule.value, "statement", null) != null ? [rule.value.statement] : []
+                  for_each = lookup(scope_down_statement.value, "byte_match_statement", null) != null ? [scope_down_statement.value.byte_match_statement] : []
 
                   content {
                     positional_constraint = byte_match_statement.value.positional_constraint
                     search_string         = byte_match_statement.value.search_string
 
                     dynamic "field_to_match" {
-                      for_each = lookup(rule.value.statement, "field_to_match", null) != null ? [rule.value.statement.field_to_match] : []
+                      for_each = lookup(byte_match_statement.value, "field_to_match", null) != null ? [byte_match_statement.value.field_to_match] : []
 
                       content {
                         dynamic "all_query_arguments" {
@@ -810,7 +810,7 @@ resource "aws_wafv2_web_acl" "default" {
                     }
 
                     dynamic "text_transformation" {
-                      for_each = lookup(rule.value.statement, "text_transformation", null) != null ? [
+                      for_each = lookup(byte_match_statement.value, "text_transformation", null) != null ? [
                         for rule in rule.value.statement.text_transformation : {
                           priority = rule.priority
                           type     = rule.type


### PR DESCRIPTION
## what

- Corrects byte_match_statement handling within scope-down rules to accurately query scope_down_statement parameters instead of the statement parameters

## why

- The current configuration produces the following error when correct variables are passed into the module:

```console
│ Error: Insufficient text_transformation blocks
│ 
│   on .terraform/dev/modules/aws_waf/rules.tf line 756, in resource "aws_wafv2_web_acl" "default":
│  756:                   content {
│ 
│ At least 1 "text_transformation" blocks are required.
╵
╷
│ Error: Unsupported attribute
│ 
│   on .terraform/dev/modules/aws_waf/rules.tf line 757, in resource "aws_wafv2_web_acl" "default":
│  757:                     positional_constraint = byte_match_statement.value.positional_constraint
│     ├────────────────
│     │ byte_match_statement.value is object with 4 attributes
│ 
│ This object does not have an attribute named "positional_constraint".
╵
╷
│ Error: Unsupported attribute
│ 
│   on .terraform/dev/modules/aws_waf/rules.tf line 758, in resource "aws_wafv2_web_acl" "default":
│  758:                     search_string         = byte_match_statement.value.search_string
│     ├────────────────
│     │ byte_match_statement.value is object with 4 attributes
│ 
│ This object does not have an attribute named "search_string".
╵
Releasing state lock. This may take a few moments...
exit status 1
```

- To correct this, this change proposes to use the proper parameters, allowing for the following values to be passed to the module:

```hcl
      scope_down_statement = optional(object({
        byte_match_statement = object({
          positional_constraint = string
          search_string         = string
          field_to_match = object({
            all_query_arguments   = optional(bool)
            body                  = optional(bool)
            method                = optional(bool)
            query_string          = optional(bool)
            single_header         = optional(object({ name = string }))
            single_query_argument = optional(object({ name = string }))
            uri_path              = optional(bool)
          })
          text_transformation = list(object({
            priority = number
            type     = string
          }))
        })
      }))
```
