### PR TITLE
feat: Configure custom_response for geo_match_statement_rules and ip_set_reference_statement_rules

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -346,7 +346,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "block" {
           for_each = rule.value.action == "block" ? [1] : []
-          content {}
+          content {
+            # Only include the custom_response block if it's present in rule.value
+            dynamic "custom_response" {
+              for_each = rule.value.custom_response != null ? [rule.value.custom_response] : []
+              content {
+                response_code            = lookup(custom_response.value, "response_code", null)
+                custom_response_body_key = lookup(custom_response.value, "custom_response_body_key", null)
+              }
+            }
+          }
         }
         dynamic "count" {
           for_each = rule.value.action == "count" ? [1] : []
@@ -420,7 +429,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "block" {
           for_each = rule.value.action == "block" ? [1] : []
-          content {}
+          content {
+            # Only include the custom_response block if it's present in rule.value
+            dynamic "custom_response" {
+              for_each = rule.value.custom_response != null ? [rule.value.custom_response] : []
+              content {
+                response_code            = lookup(custom_response.value, "response_code", null)
+                custom_response_body_key = lookup(custom_response.value, "custom_response_body_key", null)
+              }
+            }
+          }
         }
         dynamic "count" {
           for_each = rule.value.action == "count" ? [1] : []

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,14 @@ variable "geo_match_statement_rules" {
     }), null)
     rule_label = optional(list(string), null)
     statement  = any
+    custom_response = optional(object({
+      response_code            = string
+      custom_response_body_key = string
+      response_header = optional(object({
+        name  = string
+        value = string
+      }), null)
+    }), null)
     visibility_config = optional(object({
       cloudwatch_metrics_enabled = optional(bool)
       metric_name                = string
@@ -292,6 +300,14 @@ variable "ip_set_reference_statement_rules" {
     }), null)
     rule_label = optional(list(string), null)
     statement  = any
+    custom_response = optional(object({
+      response_code            = string
+      custom_response_body_key = string
+      response_header = optional(object({
+        name  = string
+        value = string
+      }), null)
+    }), null)
     visibility_config = optional(object({
       cloudwatch_metrics_enabled = optional(bool)
       metric_name                = string


### PR DESCRIPTION
feat: Configure custom_response for `geo_match_statement_rules` and `ip_set_reference_statement_rules`

## what

This is needed to return the custom response for `geo_match_statement_rules` and `ip_set_reference_statement_rules`.

## why


## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
