### PR TITLE
docs: add comment on inspection level and machine learning parameters

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -390,6 +390,8 @@ variable "managed_rule_group_statement_rules" {
         }), null)
       })), null)
       managed_rule_group_configs = optional(list(object({
+        # The `inspection_level` must be set to `TARGETED` to enable machine learning analysis
+        # https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html
         aws_managed_rules_bot_control_rule_set = optional(object({
           inspection_level        = string
           enable_machine_learning = optional(bool, true)
@@ -580,7 +582,7 @@ variable "rate_based_statement_rules" {
         field_to_match:
           Part of a web request that you want AWS WAF to inspect.
         positional_constraint:
-          Area within the portion of a web request that you want AWS WAF to search for search_string. 
+          Area within the portion of a web request that you want AWS WAF to search for search_string.
           Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`.
         search_string:
           String value that you want AWS WAF to search for.


### PR DESCRIPTION
## what

- Adds additional comments for clarity on how `inspection_levels` and `enable_machine_learning` can be configured

## why

- The Bot Control managed rule group provides two levels of protection: `COMMON` and `TARGETED`. We tested an inspection level set to `COMMON`, which uses traditional bot detection techniques, such as static request data analysis and does not support machine learning analysis. The mismatch of protection levels and configuration were causing continual drift

## references

- [AWS WAF Bot Control rule group
](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-bot.html)