### PR TITLE
Define ip_set_reference_statement_rules.statement structure to enable ip_set_forwarded_ip_config to be used.

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -398,5 +398,31 @@ module "waf" {
     }
   ]
 
+  ip_set_reference_statement_rules_forwarded_ip_config = [
+    {
+      name     = "rule-120"
+      priority = 120
+      action   = "block"
+
+      statement = {
+        ip_set = {
+          ip_address_version = "IPV4"
+          addresses          = ["18.0.0.0/8"]
+        }
+        ip_set_forwarded_ip_config = {
+          header_name       = "X-Forwarded-For"
+          fallback_behavior = "NO_MATCH"
+          position          = "FIRST"
+        }
+      }
+
+      visibility_config = {
+        cloudwatch_metrics_enabled = false
+        sampled_requests_enabled   = false
+        metric_name                = "rule-120-metric"
+      }
+    }
+  ]
+
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -291,7 +291,18 @@ variable "ip_set_reference_statement_rules" {
       })
     }), null)
     rule_label = optional(list(string), null)
-    statement  = any
+    statement  = object({
+      ip_set = object({
+        addresses          = list(string)
+        description        = optional(string)
+        ip_address_version = string
+      })
+      ip_set_forwarded_ip_config = optional(object({
+        fallback_behavior = string
+        header_name       = string
+        position          = string
+      }), null)
+    })
     visibility_config = optional(object({
       cloudwatch_metrics_enabled = optional(bool)
       metric_name                = string
@@ -580,7 +591,7 @@ variable "rate_based_statement_rules" {
         field_to_match:
           Part of a web request that you want AWS WAF to inspect.
         positional_constraint:
-          Area within the portion of a web request that you want AWS WAF to search for search_string. 
+          Area within the portion of a web request that you want AWS WAF to search for search_string.
           Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`.
         search_string:
           String value that you want AWS WAF to search for.


### PR DESCRIPTION
## what

Attempting to use the `ip_set_forwarded_ip_config` configuration was resulting in an error when attempting to use it at the appropriate level (as a sibling of `ip_set`). By defining a structure for the statement variable, we can pass the configuration in such a way that the templating creates the correct resources.

Using terraform version `Terraform v1.10.5`

## why

When attempting to provide the `ip_set_forwarded_ip_config` configuration, we saw the following error:

```
│ The given value is not suitable for
│ module.kiva-ingress-waf.var.ip_set_reference_statement_rules declared at
│ .terraform/modules/kiva-ingress-waf/variables.tf:283,1-44: cannot find a
│ common base type for all elements.
```

Attempting to nest the `ip_set_forwarded_ip_config` configuration under `ip_set` no longer produces this error, but does not result in the expected resource. Also, the documentation and naming appear to indicate that the configuration should live at the same level as `ip_set`, though it does not appear in the complete example.

The included definition allows us to configure our IP set WAF rules to include `ip_set_forwarded_ip_config` configuration.

## references

Should address https://github.com/cloudposse/terraform-aws-waf/issues/107
