### PR TITLE
feat: add scope down statement for managed rule groups

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,4 @@ output "logging_config_id" {
   description = "The ARN of the WAFv2 Web ACL logging configuration."
   value       = one(aws_wafv2_web_acl_logging_configuration.default[*].id)
 }
+

--- a/rules.tf
+++ b/rules.tf
@@ -508,6 +508,86 @@ resource "aws_wafv2_web_acl" "default" {
             vendor_name = managed_rule_group_statement.value.vendor_name
             version     = lookup(managed_rule_group_statement.value, "version", null)
 
+            dynamic "scope_down_statement" {
+              for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null ? [managed_rule_group_statement.value.scope_down_statement] : []
+
+              content {
+                dynamic "byte_match_statement" {
+                  for_each = lookup(scope_down_statement.value, "byte_match_statement", null) != null ? [scope_down_statement.value.byte_match_statement] : []
+
+                  content {
+                    positional_constraint = byte_match_statement.value.positional_constraint
+                    search_string         = byte_match_statement.value.search_string
+
+                    dynamic "field_to_match" {
+                      for_each = lookup(byte_match_statement.value, "field_to_match", null) != null ? [byte_match_statement.value.field_to_match] : []
+
+                      content {
+                        dynamic "all_query_arguments" {
+                          for_each = lookup(field_to_match.value, "all_query_arguments", null) != null ? [1] : []
+
+                          content {}
+                        }
+
+                        dynamic "body" {
+                          for_each = lookup(field_to_match.value, "body", null) != null ? [1] : []
+
+                          content {}
+                        }
+
+                        dynamic "method" {
+                          for_each = lookup(field_to_match.value, "method", null) != null ? [1] : []
+
+                          content {}
+                        }
+
+                        dynamic "query_string" {
+                          for_each = lookup(field_to_match.value, "query_string", null) != null ? [1] : []
+
+                          content {}
+                        }
+
+                        dynamic "single_header" {
+                          for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
+
+                          content {
+                            name = single_header.value.name
+                          }
+                        }
+
+                        dynamic "single_query_argument" {
+                          for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
+
+                          content {
+                            name = single_query_argument.value.name
+                          }
+                        }
+
+                        dynamic "uri_path" {
+                          for_each = lookup(field_to_match.value, "uri_path", null) != null ? [1] : []
+
+                          content {}
+                        }
+                      }
+                    }
+
+                    dynamic "text_transformation" {
+                      for_each = lookup(byte_match_statement.value, "text_transformation", null) != null ? [
+                        for rule in byte_match_statement.value.text_transformation : {
+                          priority = rule.priority
+                          type     = rule.type
+                      }] : []
+
+                      content {
+                        priority = text_transformation.value.priority
+                        type     = text_transformation.value.type
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
             dynamic "rule_action_override" {
               for_each = lookup(managed_rule_group_statement.value, "rule_action_override", null) != null ? managed_rule_group_statement.value.rule_action_override : {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -389,6 +389,25 @@ variable "managed_rule_group_statement_rules" {
           }), null)
         }), null)
       })), null)
+      scope_down_statement = optional(object({
+        byte_match_statement = object({
+          positional_constraint = string
+          search_string         = string
+          field_to_match = object({
+            all_query_arguments   = optional(bool)
+            body                  = optional(bool)
+            method                = optional(bool)
+            query_string          = optional(bool)
+            single_header         = optional(object({ name = string }))
+            single_query_argument = optional(object({ name = string }))
+            uri_path              = optional(bool)
+          })
+          text_transformation = list(object({
+            priority = number
+            type     = string
+          }))
+        })
+      }), null)
       managed_rule_group_configs = optional(list(object({
         aws_managed_rules_bot_control_rule_set = optional(object({
           inspection_level        = string
@@ -580,7 +599,7 @@ variable "rate_based_statement_rules" {
         field_to_match:
           Part of a web request that you want AWS WAF to inspect.
         positional_constraint:
-          Area within the portion of a web request that you want AWS WAF to search for search_string. 
+          Area within the portion of a web request that you want AWS WAF to search for search_string.
           Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`.
         search_string:
           String value that you want AWS WAF to search for.


### PR DESCRIPTION
## what

- Add the ability to use `scope_down_statements` with managed rule groups

## references

- [Scoping Bot Control Rules](https://docs.aws.amazon.com/waf/latest/developerguide/waf-bot-control-example-scope-down-your-bot.html)