### PR TITLE
feat: add the ability to negate `scope_down_statements` in managed rules

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -673,7 +673,7 @@ resource "aws_wafv2_web_acl" "default" {
             }
 
             dynamic "scope_down_statement" {
-              for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null && !lookup(managed_rule_group_statement.value, "use_not_statement_for_scope_down", false) ? [managed_rule_group_statement.value.scope_down_statement] : []
+              for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null && !lookup(managed_rule_group_statement.value, "scope_down_not_statement_enabled", false) ? [managed_rule_group_statement.value.scope_down_statement] : []
               content {
                 dynamic "byte_match_statement" {
                   for_each = lookup(scope_down_statement.value, "byte_match_statement", null) != null ? [scope_down_statement.value.byte_match_statement] : []
@@ -734,7 +734,7 @@ resource "aws_wafv2_web_acl" "default" {
             }
 
             dynamic "scope_down_statement" {
-              for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null && lookup(managed_rule_group_statement.value, "use_not_statement_for_scope_down", false) ? [managed_rule_group_statement.value.scope_down_statement] : []
+              for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null && lookup(managed_rule_group_statement.value, "scope_down_not_statement_enabled", false) ? [managed_rule_group_statement.value.scope_down_statement] : []
               content {
                 not_statement {
                   statement {

--- a/rules.tf
+++ b/rules.tf
@@ -674,55 +674,67 @@ resource "aws_wafv2_web_acl" "default" {
 
             dynamic "scope_down_statement" {
               for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null && !lookup(managed_rule_group_statement.value, "scope_down_not_statement_enabled", false) ? [managed_rule_group_statement.value.scope_down_statement] : []
+
               content {
                 dynamic "byte_match_statement" {
                   for_each = lookup(scope_down_statement.value, "byte_match_statement", null) != null ? [scope_down_statement.value.byte_match_statement] : []
+
                   content {
                     positional_constraint = byte_match_statement.value.positional_constraint
                     search_string         = byte_match_statement.value.search_string
+
                     dynamic "field_to_match" {
                       for_each = lookup(byte_match_statement.value, "field_to_match", null) != null ? [byte_match_statement.value.field_to_match] : []
+
                       content {
                         dynamic "all_query_arguments" {
                           for_each = lookup(field_to_match.value, "all_query_arguments", null) != null ? [1] : []
                           content {}
                         }
+
                         dynamic "body" {
                           for_each = lookup(field_to_match.value, "body", null) != null ? [1] : []
                           content {}
                         }
+
                         dynamic "method" {
                           for_each = lookup(field_to_match.value, "method", null) != null ? [1] : []
                           content {}
                         }
+
                         dynamic "query_string" {
                           for_each = lookup(field_to_match.value, "query_string", null) != null ? [1] : []
                           content {}
                         }
+
                         dynamic "single_header" {
                           for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
                           content {
                             name = single_header.value.name
                           }
                         }
+
                         dynamic "single_query_argument" {
                           for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
                           content {
                             name = single_query_argument.value.name
                           }
                         }
+
                         dynamic "uri_path" {
                           for_each = lookup(field_to_match.value, "uri_path", null) != null ? [1] : []
                           content {}
                         }
                       }
                     }
+
                     dynamic "text_transformation" {
                       for_each = lookup(byte_match_statement.value, "text_transformation", null) != null ? [
                         for rule in byte_match_statement.value.text_transformation : {
                           priority = rule.priority
                           type     = rule.type
                       }] : []
+
                       content {
                         priority = text_transformation.value.priority
                         type     = text_transformation.value.type
@@ -735,57 +747,69 @@ resource "aws_wafv2_web_acl" "default" {
 
             dynamic "scope_down_statement" {
               for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null && lookup(managed_rule_group_statement.value, "scope_down_not_statement_enabled", false) ? [managed_rule_group_statement.value.scope_down_statement] : []
+
               content {
                 not_statement {
                   statement {
                     dynamic "byte_match_statement" {
                       for_each = lookup(scope_down_statement.value, "byte_match_statement", null) != null ? [scope_down_statement.value.byte_match_statement] : []
+
                       content {
                         positional_constraint = byte_match_statement.value.positional_constraint
                         search_string         = byte_match_statement.value.search_string
+
                         dynamic "field_to_match" {
                           for_each = lookup(byte_match_statement.value, "field_to_match", null) != null ? [byte_match_statement.value.field_to_match] : []
+
                           content {
                             dynamic "all_query_arguments" {
                               for_each = lookup(field_to_match.value, "all_query_arguments", null) != null ? [1] : []
                               content {}
                             }
+
                             dynamic "body" {
                               for_each = lookup(field_to_match.value, "body", null) != null ? [1] : []
                               content {}
                             }
+
                             dynamic "method" {
                               for_each = lookup(field_to_match.value, "method", null) != null ? [1] : []
                               content {}
                             }
+
                             dynamic "query_string" {
                               for_each = lookup(field_to_match.value, "query_string", null) != null ? [1] : []
                               content {}
                             }
+
                             dynamic "single_header" {
                               for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
                               content {
                                 name = single_header.value.name
                               }
                             }
+
                             dynamic "single_query_argument" {
                               for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
                               content {
                                 name = single_query_argument.value.name
                               }
                             }
+
                             dynamic "uri_path" {
                               for_each = lookup(field_to_match.value, "uri_path", null) != null ? [1] : []
                               content {}
                             }
                           }
                         }
+
                         dynamic "text_transformation" {
                           for_each = lookup(byte_match_statement.value, "text_transformation", null) != null ? [
                             for rule in byte_match_statement.value.text_transformation : {
                               priority = rule.priority
                               type     = rule.type
                           }] : []
+
                           content {
                             priority = text_transformation.value.priority
                             type     = text_transformation.value.type

--- a/rules.tf
+++ b/rules.tf
@@ -673,78 +673,124 @@ resource "aws_wafv2_web_acl" "default" {
             }
 
             dynamic "scope_down_statement" {
-              for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null ? [managed_rule_group_statement.value.scope_down_statement] : []
-
+              for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null && !lookup(managed_rule_group_statement.value, "use_not_statement_for_scope_down", false) ? [managed_rule_group_statement.value.scope_down_statement] : []
               content {
                 dynamic "byte_match_statement" {
                   for_each = lookup(scope_down_statement.value, "byte_match_statement", null) != null ? [scope_down_statement.value.byte_match_statement] : []
-
                   content {
                     positional_constraint = byte_match_statement.value.positional_constraint
                     search_string         = byte_match_statement.value.search_string
-
                     dynamic "field_to_match" {
                       for_each = lookup(byte_match_statement.value, "field_to_match", null) != null ? [byte_match_statement.value.field_to_match] : []
-
                       content {
                         dynamic "all_query_arguments" {
                           for_each = lookup(field_to_match.value, "all_query_arguments", null) != null ? [1] : []
-
                           content {}
                         }
-
                         dynamic "body" {
                           for_each = lookup(field_to_match.value, "body", null) != null ? [1] : []
-
                           content {}
                         }
-
                         dynamic "method" {
                           for_each = lookup(field_to_match.value, "method", null) != null ? [1] : []
-
                           content {}
                         }
-
                         dynamic "query_string" {
                           for_each = lookup(field_to_match.value, "query_string", null) != null ? [1] : []
-
                           content {}
                         }
-
                         dynamic "single_header" {
                           for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
-
                           content {
                             name = single_header.value.name
                           }
                         }
-
                         dynamic "single_query_argument" {
                           for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
-
                           content {
                             name = single_query_argument.value.name
                           }
                         }
-
                         dynamic "uri_path" {
                           for_each = lookup(field_to_match.value, "uri_path", null) != null ? [1] : []
-
                           content {}
                         }
                       }
                     }
-
                     dynamic "text_transformation" {
                       for_each = lookup(byte_match_statement.value, "text_transformation", null) != null ? [
                         for rule in byte_match_statement.value.text_transformation : {
                           priority = rule.priority
                           type     = rule.type
                       }] : []
-
                       content {
                         priority = text_transformation.value.priority
                         type     = text_transformation.value.type
+                      }
+                    }
+                  }
+                }
+              }
+            }
+
+            dynamic "scope_down_statement" {
+              for_each = lookup(managed_rule_group_statement.value, "scope_down_statement", null) != null && lookup(managed_rule_group_statement.value, "use_not_statement_for_scope_down", false) ? [managed_rule_group_statement.value.scope_down_statement] : []
+              content {
+                not_statement {
+                  statement {
+                    dynamic "byte_match_statement" {
+                      for_each = lookup(scope_down_statement.value, "byte_match_statement", null) != null ? [scope_down_statement.value.byte_match_statement] : []
+                      content {
+                        positional_constraint = byte_match_statement.value.positional_constraint
+                        search_string         = byte_match_statement.value.search_string
+                        dynamic "field_to_match" {
+                          for_each = lookup(byte_match_statement.value, "field_to_match", null) != null ? [byte_match_statement.value.field_to_match] : []
+                          content {
+                            dynamic "all_query_arguments" {
+                              for_each = lookup(field_to_match.value, "all_query_arguments", null) != null ? [1] : []
+                              content {}
+                            }
+                            dynamic "body" {
+                              for_each = lookup(field_to_match.value, "body", null) != null ? [1] : []
+                              content {}
+                            }
+                            dynamic "method" {
+                              for_each = lookup(field_to_match.value, "method", null) != null ? [1] : []
+                              content {}
+                            }
+                            dynamic "query_string" {
+                              for_each = lookup(field_to_match.value, "query_string", null) != null ? [1] : []
+                              content {}
+                            }
+                            dynamic "single_header" {
+                              for_each = lookup(field_to_match.value, "single_header", null) != null ? [field_to_match.value.single_header] : []
+                              content {
+                                name = single_header.value.name
+                              }
+                            }
+                            dynamic "single_query_argument" {
+                              for_each = lookup(field_to_match.value, "single_query_argument", null) != null ? [field_to_match.value.single_query_argument] : []
+                              content {
+                                name = single_query_argument.value.name
+                              }
+                            }
+                            dynamic "uri_path" {
+                              for_each = lookup(field_to_match.value, "uri_path", null) != null ? [1] : []
+                              content {}
+                            }
+                          }
+                        }
+                        dynamic "text_transformation" {
+                          for_each = lookup(byte_match_statement.value, "text_transformation", null) != null ? [
+                            for rule in byte_match_statement.value.text_transformation : {
+                              priority = rule.priority
+                              type     = rule.type
+                          }] : []
+                          content {
+                            priority = text_transformation.value.priority
+                            type     = text_transformation.value.type
+                          }
+                        }
                       }
                     }
                   }

--- a/variables.tf
+++ b/variables.tf
@@ -370,9 +370,29 @@ variable "managed_rule_group_statement_rules" {
     }), null)
     rule_label = optional(list(string), null)
     statement = object({
-      name        = string
-      vendor_name = string
-      version     = optional(string)
+      name                             = string
+      vendor_name                      = string
+      use_not_statement_for_scope_down = optional(bool, false)
+      scope_down_statement = optional(object({
+        byte_match_statement = object({
+          positional_constraint = string
+          search_string         = string
+          field_to_match = object({
+            all_query_arguments   = optional(bool)
+            body                  = optional(bool)
+            method                = optional(bool)
+            query_string          = optional(bool)
+            single_header         = optional(object({ name = string }))
+            single_query_argument = optional(object({ name = string }))
+            uri_path              = optional(bool)
+          })
+          text_transformation = list(object({
+            priority = number
+            type     = string
+          }))
+        })
+      }), null)
+      version = optional(string)
       rule_action_override = optional(map(object({
         action = string
         custom_request_handling = optional(object({
@@ -429,25 +449,6 @@ variable "managed_rule_group_statement_rules" {
           }), null)
         }), null)
       })), null)
-      scope_down_statement = optional(object({
-        byte_match_statement = object({
-          positional_constraint = string
-          search_string         = string
-          field_to_match = object({
-            all_query_arguments   = optional(bool)
-            body                  = optional(bool)
-            method                = optional(bool)
-            query_string          = optional(bool)
-            single_header         = optional(object({ name = string }))
-            single_query_argument = optional(object({ name = string }))
-            uri_path              = optional(bool)
-          })
-          text_transformation = list(object({
-            priority = number
-            type     = string
-          }))
-        })
-      }), null)
     })
     visibility_config = optional(object({
       cloudwatch_metrics_enabled = optional(bool)
@@ -599,7 +600,7 @@ variable "rate_based_statement_rules" {
         field_to_match:
           Part of a web request that you want AWS WAF to inspect.
         positional_constraint:
-          Area within the portion of a web request that you want AWS WAF to search for search_string. 
+          Area within the portion of a web request that you want AWS WAF to search for search_string.
           Valid values include the following: `EXACTLY`, `STARTS_WITH`, `ENDS_WITH`, `CONTAINS`, `CONTAINS_WORD`.
         search_string:
           String value that you want AWS WAF to search for.

--- a/variables.tf
+++ b/variables.tf
@@ -372,7 +372,7 @@ variable "managed_rule_group_statement_rules" {
     statement = object({
       name                             = string
       vendor_name                      = string
-      use_not_statement_for_scope_down = optional(bool, false)
+      scope_down_not_statement_enabled = optional(bool, false)
       scope_down_statement = optional(object({
         byte_match_statement = object({
           positional_constraint = string


### PR DESCRIPTION
## what

> [!WARNING]
> The WAF rules are convoluted and complex, so this change just adds a simple toggle to allow negating `scope_down_statements` to work with AWS' recommendation for bypassing bot control rules. This change has been testing with existing infrastructure to ensure it's backward compatible

- Add a `scope_down_not_statement_enabled` to allow `not_statements` (**NOTE:** This name is not pretty, so I'm open to better names if you have any)

## why

- AWS recommends bypassing bot control rules via the following method, which adds a `not_statement` to the `scope_down_statement` for managed rules. The current implementation does not allow for this, but this addition will allow the following:

```json
{
  "Name": "AWS-AWSBotControl-Example",
  "Priority": 5,
  "Statement": {
    "ManagedRuleGroupStatement": {
      "VendorName": "AWS",
      "Name": "AWSManagedRulesBotControlRuleSet",
      "ManagedRuleGroupConfigs": [
        {
          "AWSManagedRulesBotControlRuleSet": {
            "InspectionLevel": "COMMON"
          }
        }
      ],
      "RuleActionOverrides": [],
      "ExcludedRules": []
    },
    "VisibilityConfig": {
      "SampledRequestsEnabled": true,
      "CloudWatchMetricsEnabled": true,
      "MetricName": "AWS-AWSBotControl-Example"
    },
    "ScopeDownStatement": {
      "NotStatement": {
        "Statement": {
          "ByteMatchStatement": {
            "SearchString": "YSBzZWNyZXQ=",
            "FieldToMatch": {
              "SingleHeader": {
                "Name": "x-bypass-secret"
              }
            },
            "TextTransformations": [
              {
                "Priority": 0,
                "Type": "NONE"
              }
            ],
            "PositionalConstraint": "EXACTLY"
          }
        }
      }
    }
  }
}
```

## testing

- [X] Successfully ran the following:

```sh
atmos validate stacks
atmos terraform apply waf -s <stack>
```

## references

- [Allowing traffic from a bot you control](https://github.com/cloudposse/terraform-aws-waf/compare/main...The-Infra-Company:terraform-aws-waf:add-functionality-to-managed-rules?expand=1)