### PR TITLE
chore(deps): update AWS provider to >= 6.2.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.2.0"
     }
   }
 }


### PR DESCRIPTION
## what

This pull request updates the AWS provider version constraint in the Terraform configuration to require a more recent version.

  * Increased the minimum required version of the `aws` provider from `5.0` to `6.2.0` in `versions.tf` to ensure compatibility with newer AWS features and APIs.

## why

- Ensure the module is pinning the required version for parameters and resources supported by this module

## references

- [Provider Changelog](https://github.com/hashicorp/terraform-provider-aws/blob/3b9d770b6bdf8771c0965241e534af57c2e9dd93/CHANGELOG.md?plain=1#L510)