### PR TITLE
Add challenge action and config in missing rules

### DIFF
--- a/rules.tf
+++ b/rules.tf
@@ -290,6 +290,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
       }
 
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
       dynamic "rule_label" {
         for_each = lookup(rule.value, "rule_label", null) != null ? rule.value.rule_label : []
         content {
@@ -366,6 +376,16 @@ resource "aws_wafv2_web_acl" "default" {
           }
         }
       }
+
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
     }
   }
 
@@ -408,6 +428,10 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = rule.value.action == "captcha" ? [1] : []
           content {}
         }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
+          content {}
+        }
       }
 
       statement {
@@ -445,6 +469,16 @@ resource "aws_wafv2_web_acl" "default" {
         content {
           immunity_time_property {
             immunity_time = captcha_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
           }
         }
       }
@@ -497,6 +531,10 @@ resource "aws_wafv2_web_acl" "default" {
           for_each = rule.value.action == "captcha" ? [1] : []
           content {}
         }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
+          content {}
+        }
       }
 
       statement {
@@ -535,6 +573,16 @@ resource "aws_wafv2_web_acl" "default" {
         content {
           immunity_time_property {
             immunity_time = captcha_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
           }
         }
       }
@@ -1015,6 +1063,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
       }
 
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
       dynamic "rule_label" {
         for_each = lookup(rule.value, "rule_label", null) != null ? rule.value.rule_label : []
         content {
@@ -1034,6 +1092,10 @@ resource "aws_wafv2_web_acl" "default" {
       action {
         dynamic "allow" {
           for_each = rule.value.action == "allow" ? [1] : []
+          content {}
+        }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
           content {}
         }
         dynamic "block" {
@@ -1061,6 +1123,10 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "captcha" {
           for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
           content {}
         }
       }
@@ -1182,6 +1248,16 @@ resource "aws_wafv2_web_acl" "default" {
         content {
           immunity_time_property {
             immunity_time = captcha_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
           }
         }
       }
@@ -1312,6 +1388,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
       }
 
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
       dynamic "rule_label" {
         for_each = lookup(rule.value, "rule_label", null) != null ? rule.value.rule_label : []
         content {
@@ -1335,6 +1421,10 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "block" {
           for_each = rule.value.action == "block" ? [1] : []
+          content {}
+        }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
           content {}
         }
         dynamic "count" {
@@ -1434,6 +1524,16 @@ resource "aws_wafv2_web_acl" "default" {
         content {
           immunity_time_property {
             immunity_time = captcha_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
           }
         }
       }
@@ -1587,6 +1687,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
       }
 
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
       dynamic "rule_label" {
         for_each = lookup(rule.value, "rule_label", null) != null ? rule.value.rule_label : []
         content {
@@ -1618,6 +1728,10 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "captcha" {
           for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
           content {}
         }
       }
@@ -1724,6 +1838,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
       }
 
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
       dynamic "rule_label" {
         for_each = lookup(rule.value, "rule_label", null) != null ? rule.value.rule_label : []
         content {
@@ -1755,6 +1879,10 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "captcha" {
           for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
           content {}
         }
       }
@@ -1853,6 +1981,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
       }
 
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
       dynamic "rule_label" {
         for_each = lookup(rule.value, "rule_label", null) != null ? rule.value.rule_label : []
         content {
@@ -1884,6 +2022,10 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "captcha" {
           for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
           content {}
         }
       }
@@ -1982,6 +2124,16 @@ resource "aws_wafv2_web_acl" "default" {
         }
       }
 
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
       dynamic "rule_label" {
         for_each = lookup(rule.value, "rule_label", null) != null ? rule.value.rule_label : []
         content {
@@ -2028,6 +2180,10 @@ resource "aws_wafv2_web_acl" "default" {
         }
         dynamic "captcha" {
           for_each = rule.value.action == "captcha" ? [1] : []
+          content {}
+        }
+        dynamic "challenge" {
+          for_each = rule.value.action == "challenge" ? [1] : []
           content {}
         }
       }
@@ -2101,6 +2257,16 @@ resource "aws_wafv2_web_acl" "default" {
         content {
           immunity_time_property {
             immunity_time = captcha_config.value.immunity_time_property.immunity_time
+          }
+        }
+      }
+
+      dynamic "challenge_config" {
+        for_each = lookup(rule.value, "challenge_config", null) != null ? [rule.value.challenge_config] : []
+
+        content {
+          immunity_time_property {
+            immunity_time = challenge_config.value.immunity_time_property.immunity_time
           }
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,11 @@ variable "byte_match_statement_rules" {
         immunity_time = number
       })
     }), null)
+    challenge_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
     rule_label = optional(list(string), null)
     custom_response = optional(object({
       response_code            = string
@@ -131,6 +136,15 @@ variable "byte_match_statement_rules" {
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
 
@@ -168,6 +182,11 @@ variable "geo_allowlist_statement_rules" {
         immunity_time = number
       })
     }), null)
+    challenge_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
     rule_label = optional(list(string), null)
     statement  = any
     visibility_config = optional(object({
@@ -197,6 +216,15 @@ variable "geo_allowlist_statement_rules" {
 
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
@@ -229,6 +257,11 @@ variable "geo_match_statement_rules" {
     priority = number
     action   = string
     captcha_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
+    challenge_config = optional(object({
       immunity_time_property = object({
         immunity_time = number
       })
@@ -271,6 +304,15 @@ variable "geo_match_statement_rules" {
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
 
@@ -302,6 +344,11 @@ variable "ip_set_reference_statement_rules" {
     priority = number
     action   = string
     captcha_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
+    challenge_config = optional(object({
       immunity_time_property = object({
         immunity_time = number
       })
@@ -343,6 +390,15 @@ variable "ip_set_reference_statement_rules" {
 
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
@@ -388,6 +444,11 @@ variable "managed_rule_group_statement_rules" {
     priority        = number
     override_action = optional(string)
     captcha_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
+    challenge_config = optional(object({
       immunity_time_property = object({
         immunity_time = number
       })
@@ -560,6 +621,15 @@ variable "managed_rule_group_statement_rules" {
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
 
@@ -596,6 +666,11 @@ variable "rate_based_statement_rules" {
     priority = number
     action   = string
     captcha_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
+    challenge_config = optional(object({
       immunity_time_property = object({
         immunity_time = number
       })
@@ -666,6 +741,15 @@ variable "rate_based_statement_rules" {
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
 
@@ -731,6 +815,11 @@ variable "regex_pattern_set_reference_statement_rules" {
         immunity_time = number
       })
     }), null)
+    challenge_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
     rule_label = optional(list(string), null)
     statement  = any
     visibility_config = optional(object({
@@ -760,6 +849,15 @@ variable "regex_pattern_set_reference_statement_rules" {
 
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
@@ -796,6 +894,11 @@ variable "regex_match_statement_rules" {
         immunity_time = number
       })
     }), null)
+    challenge_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
     rule_label = optional(list(string), null)
     statement  = any
     visibility_config = optional(object({
@@ -825,6 +928,15 @@ variable "regex_match_statement_rules" {
 
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
@@ -857,6 +969,11 @@ variable "rule_group_reference_statement_rules" {
     priority        = number
     override_action = optional(string)
     captcha_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
+    challenge_config = optional(object({
       immunity_time_property = object({
         immunity_time = number
       })
@@ -911,6 +1028,15 @@ variable "rule_group_reference_statement_rules" {
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
 
@@ -939,6 +1065,11 @@ variable "size_constraint_statement_rules" {
     priority = number
     action   = string
     captcha_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
+    challenge_config = optional(object({
       immunity_time_property = object({
         immunity_time = number
       })
@@ -972,6 +1103,15 @@ variable "size_constraint_statement_rules" {
 
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
     rule_label:
        A List of labels to apply to web requests that match the rule match statement
@@ -1012,6 +1152,11 @@ variable "sqli_match_statement_rules" {
         immunity_time = number
       })
     }), null)
+    challenge_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
     rule_label = optional(list(string), null)
     statement  = any
     visibility_config = optional(object({
@@ -1046,6 +1191,15 @@ variable "sqli_match_statement_rules" {
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
     statement:
       field_to_match:
         The part of a web request that you want AWS WAF to inspect.
@@ -1072,6 +1226,11 @@ variable "xss_match_statement_rules" {
     priority = number
     action   = string
     captcha_config = optional(object({
+      immunity_time_property = object({
+        immunity_time = number
+      })
+    }), null)
+    challenge_config = optional(object({
       immunity_time_property = object({
         immunity_time = number
       })
@@ -1105,6 +1264,15 @@ variable "xss_match_statement_rules" {
 
        immunity_time:
        The amount of time, in seconds, that a CAPTCHA or challenge timestamp is considered valid by AWS WAF. The default setting is 300.
+
+    challenge_config:
+     Specifies how AWS WAF should handle challenge evaluations.
+
+     immunity_time_property:
+       Defines custom immunity time.
+
+       immunity_time:
+       The amount of time, in seconds, that a challenge timestamp is considered valid by AWS WAF. The default setting is 300.
 
     rule_label:
        A List of labels to apply to web requests that match the rule match statement


### PR DESCRIPTION
## what

Challenge action allows less intrusive filter and it is a supported AWS WAF feature that is missing in this module.
## why

We use challenge action to block "Browser" like traffic

## references

None
